### PR TITLE
Fix random generator

### DIFF
--- a/examples/tls-echo/echo.cpp
+++ b/examples/tls-echo/echo.cpp
@@ -442,7 +442,10 @@ echo::server::server(
     const std::string& cert_file, 
     const std::string& key_file, 
     const uint16_t port, 
-    const uint32_t threads) : _ctx(ice::SERVER_TCP_SOCKET,cert_file,key_file)
+    const uint32_t threads) : _ctx(
+        ice::SERVER_TCP_SOCKET,
+        cert_file,key_file), _random_engine(
+        std::random_device())
 {
     _port = port;
     _threads = threads;

--- a/examples/tls-echo/echo.cpp
+++ b/examples/tls-echo/echo.cpp
@@ -445,7 +445,7 @@ echo::server::server(
     const uint32_t threads) : _ctx(
         ice::SERVER_TCP_SOCKET,
         cert_file,key_file), _random_engine(
-        std::random_device())
+        std::random_device()())
 {
     _port = port;
     _threads = threads;


### PR DESCRIPTION
Random engine needs to be seeded to provide nondeterministic results on calls to `std::shuffle`.